### PR TITLE
Update header imports to match RN 0.40

### DIFF
--- a/ios/OAuthManager/OAuthManager.h
+++ b/ios/OAuthManager/OAuthManager.h
@@ -7,8 +7,8 @@
 
 #import <Foundation/Foundation.h>
 
-#import "RCTBridgeModule.h"
-#import "RCTLinkingManager.h"
+#import <React/RCTBridgeModule.h>
+#import <React/RCTLinkingManager.h>
 
 @class OAuthClient;
 


### PR DESCRIPTION
Current version doesn't work with react-native 0.40 because all header imports was moved to `<React/...>`
https://github.com/facebook/react-native/releases/tag/v0.40.0
This PR will fix that.