### PR TITLE
[fix]: for Google authentication make sure the clientID is present when performing authorization

### DIFF
--- a/ios/OAuthManager/OAuthManager.m
+++ b/ios/OAuthManager/OAuthManager.m
@@ -294,7 +294,9 @@ RCT_EXPORT_METHOD(authorize:(NSString *)providerName
     NSMutableDictionary *cfg = [[manager getConfigForProvider:providerName] mutableCopy];
     
     DCTAuthAccount *existingAccount = [manager accountForProvider:providerName];
-    if (existingAccount != nil) {
+    NSString *clientID = ((DCTOAuth2Credential *) existingAccount).clientID;
+    if (([providerName isEqualToString:@"google"] && existingAccount && clientID != nil)
+        || (![providerName isEqualToString:@"google"] && existingAccount != nil)) {
         if ([existingAccount isAuthorized]) {
             NSDictionary *accountResponse = [manager getAccountResponse:existingAccount cfg:cfg];
             callback(@[[NSNull null], @{


### PR DESCRIPTION
DCTAuthAccountStore fails on deleting account when deauthorization is made,  it happens on real device pretty often. The account only looses the clientID then the authorization gets stuck afterwards, because when authorizing it only checks if it's null and so when it tries to perform auth using the existing account there's not enough information.