### PR TITLE
Use the protected `getCurrentActivity` method

### DIFF
--- a/android/src/main/java/io/fullstack/oauth/OAuthManagerModule.java
+++ b/android/src/main/java/io/fullstack/oauth/OAuthManagerModule.java
@@ -83,8 +83,8 @@ class OAuthManagerModule extends ReactContextBaseJavaModule {
 
   @ReactMethod
   public void configureProvider(
-    final String providerName, 
-    final ReadableMap params, 
+    final String providerName,
+    final ReadableMap params,
     @Nullable final Callback onComplete
   ) {
     Log.i(TAG, "configureProvider for " + providerName);
@@ -92,7 +92,7 @@ class OAuthManagerModule extends ReactContextBaseJavaModule {
     // Save callback url for later
     String callbackUrlStr = params.getString("callback_url");
     _callbackUrls.add(callbackUrlStr);
-    
+
     Log.d(TAG, "Added callback url " + callbackUrlStr + " for providler " + providerName);
 
     // Keep configuration map
@@ -120,18 +120,18 @@ class OAuthManagerModule extends ReactContextBaseJavaModule {
 
   @ReactMethod
   public void authorize(
-    final String providerName, 
-    @Nullable final ReadableMap params, 
-    final Callback callback) 
+    final String providerName,
+    @Nullable final ReadableMap params,
+    final Callback callback)
   {
     try {
       final OAuthManagerModule self = this;
       final HashMap<String,Object> cfg = this.getConfiguration(providerName);
       final String authVersion = (String) cfg.get("auth_version");
-      Activity activity = mReactContext.getCurrentActivity();
+      Activity activity = getCurrentActivity();
       FragmentManager fragmentManager = activity.getFragmentManager();
       String callbackUrl = "http://localhost/" + providerName;
-      
+
       OAuthManagerOnAccessTokenListener listener = new OAuthManagerOnAccessTokenListener() {
         public void onRequestTokenError(final Exception ex) {
           Log.e(TAG, "Exception with request token: " + ex.getMessage());
@@ -155,7 +155,7 @@ class OAuthManagerModule extends ReactContextBaseJavaModule {
       };
 
       if (authVersion.equals("1.0")) {
-        final OAuth10aService service = 
+        final OAuth10aService service =
           OAuthManagerProviders.getApiFor10aProvider(providerName, cfg, params, callbackUrl);
 
         OAuthManagerFragmentController ctrl =
@@ -165,7 +165,7 @@ class OAuthManagerModule extends ReactContextBaseJavaModule {
       } else if (authVersion.equals("2.0")) {
         final OAuth20Service service =
           OAuthManagerProviders.getApiFor20Provider(providerName, cfg, params, callbackUrl);
-        
+
         OAuthManagerFragmentController ctrl =
           new OAuthManagerFragmentController(mReactContext, fragmentManager, providerName, service, callbackUrl);
 
@@ -181,9 +181,9 @@ class OAuthManagerModule extends ReactContextBaseJavaModule {
 
   @ReactMethod
   public void makeRequest(
-    final String providerName, 
+    final String providerName,
     final String urlString,
-    final ReadableMap params, 
+    final ReadableMap params,
     final Callback onComplete) {
 
       Log.i(TAG, "makeRequest called for " + providerName + " to " + urlString);
@@ -206,7 +206,7 @@ class OAuthManagerModule extends ReactContextBaseJavaModule {
         }
 
         String httpMethod;
-        if (params.hasKey("method")) { 
+        if (params.hasKey("method")) {
           httpMethod = params.getString("method");
         } else {
           httpMethod = "GET";
@@ -231,8 +231,8 @@ class OAuthManagerModule extends ReactContextBaseJavaModule {
           httpVerb = Verb.TRACE;
         } else {
           httpVerb = Verb.GET;
-        }        
-        
+        }
+
         ReadableMap requestParams = null;
         if (params != null && params.hasKey("params")) {
           requestParams = params.getMap("params");
@@ -240,10 +240,10 @@ class OAuthManagerModule extends ReactContextBaseJavaModule {
         OAuthRequest request = oauthRequestWithParams(providerName, cfg, authVersion, httpVerb, url, requestParams);
 
         if (authVersion.equals("1.0")) {
-          final OAuth10aService service = 
+          final OAuth10aService service =
             OAuthManagerProviders.getApiFor10aProvider(providerName, cfg, requestParams, null);
           OAuth1AccessToken token = _credentialsStore.get(providerName, OAuth1AccessToken.class);
-          
+
           service.signRequest(token, request);
         } else if (authVersion.equals("2.0")) {
           final OAuth20Service service =
@@ -260,7 +260,7 @@ class OAuthManagerModule extends ReactContextBaseJavaModule {
           onComplete.invoke(err);
           return;
         }
-        
+
         final Response response = request.send();
         final String rawBody = response.getBody();
 
@@ -271,7 +271,7 @@ class OAuthManagerModule extends ReactContextBaseJavaModule {
         resp.putInt("status", response.getCode());
         resp.putString("data", rawBody);
         onComplete.invoke(null, resp);
- 
+
       } catch (IOException ex) {
         Log.e(TAG, "IOException when making request: " + ex.getMessage());
         ex.printStackTrace();
@@ -293,18 +293,18 @@ class OAuthManagerModule extends ReactContextBaseJavaModule {
     OAuthRequest request;
     // OAuthConfig config;
 
-    if (authVersion.equals("1.0")) {  
-      // final OAuth10aService service = 
+    if (authVersion.equals("1.0")) {
+      // final OAuth10aService service =
           // OAuthManagerProviders.getApiFor10aProvider(providerName, cfg, null, null);
       OAuth1AccessToken oa1token = _credentialsStore.get(providerName, OAuth1AccessToken.class);
       request = OAuthManagerProviders.getRequestForProvider(
-        providerName, 
+        providerName,
         httpVerb,
-        oa1token, 
+        oa1token,
         url,
         cfg,
         params);
-      
+
       // config = service.getConfig();
       // request = new OAuthRequest(httpVerb, url.toString(), config);
     } else if (authVersion.equals("2.0")) {
@@ -314,13 +314,13 @@ class OAuthManagerModule extends ReactContextBaseJavaModule {
 
       OAuth2AccessToken oa2token = _credentialsStore.get(providerName, OAuth2AccessToken.class);
       request = OAuthManagerProviders.getRequestForProvider(
-        providerName, 
+        providerName,
         httpVerb,
-        oa2token, 
+        oa2token,
         url,
         cfg,
         params);
-      
+
       // config = service.getConfig();
       // request = new OAuthRequest(httpVerb, url.toString(), config);
     } else {
@@ -338,8 +338,8 @@ class OAuthManagerModule extends ReactContextBaseJavaModule {
 
   @ReactMethod
   public void getSavedAccount(
-    final String providerName, 
-    final ReadableMap options, 
+    final String providerName,
+    final ReadableMap options,
     final Callback onComplete)
   {
     try {
@@ -359,7 +359,7 @@ class OAuthManagerModule extends ReactContextBaseJavaModule {
         onComplete.invoke(null, resp);
       } else if (authVersion.equals("2.0")) {
         OAuth2AccessToken token = _credentialsStore.get(providerName, OAuth2AccessToken.class);
-        
+
         if (token == null || token.equals("")) {
           throw new Exception("No token found");
         }
@@ -376,7 +376,7 @@ class OAuthManagerModule extends ReactContextBaseJavaModule {
       ex.printStackTrace();
       exceptionCallback(ex, onComplete);
     }
-    
+
   }
 
   @ReactMethod
@@ -424,7 +424,7 @@ class OAuthManagerModule extends ReactContextBaseJavaModule {
     resp.putBoolean("authorized", true);
     resp.putString("provider", providerName);
     response.putString("uuid", accessToken.getParameter("user_id"));
-    
+
     String tokenType = accessToken.getParameter("token_type");
     if (tokenType == null) {
       tokenType = "Bearer";
@@ -463,7 +463,7 @@ class OAuthManagerModule extends ReactContextBaseJavaModule {
       Log.e(TAG, "Exception while getting the access token");
       ex.printStackTrace();
     }
-    
+
     WritableMap credentials = Arguments.createMap();
     Log.d(TAG, "Credential raw response: " + accessToken.getRawResponse());
 
@@ -474,7 +474,7 @@ class OAuthManagerModule extends ReactContextBaseJavaModule {
     if (tokenType == null) {
       tokenType = "Bearer";
     }
-    
+
     String scope = accessToken.getScope();
     if (scope == null) {
       scope = (String) cfg.get("scopes");


### PR DESCRIPTION
`ReactContext#getCurrentActivity` is a protected method and can't be
called on an instance of `ReactContext`.

Instead, as `OAuthManagerModule` extends `ReactContextBaseJavaModule` we
have access to the `getCurrentActivity()` method there and can use that
to avoid the access problem.