### PR TITLE
Don't url encode provider config

### DIFF
--- a/ios/OAuthManager/OAuthManager.m
+++ b/ios/OAuthManager/OAuthManager.m
@@ -149,14 +149,11 @@ RCT_EXPORT_MODULE(OAuthManager);
         if ([name rangeOfString:@"_url"].location != NSNotFound) {
             // This is a URL representation
             NSString *urlStr = [config valueForKey:name];
-            NSURL *url = [NSURL URLWithString:[urlStr
-                                               stringByAddingPercentEscapesUsingEncoding:NSUTF8StringEncoding]];
+            NSURL *url = [NSURL URLWithString:urlStr];
             [objectProps setObject:url forKey:name];
         } else {
             NSString *str = [NSString stringWithString:[config valueForKey:name]];
-            NSString *escapedStr = [str
-                                    stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet URLHostAllowedCharacterSet]];
-            [objectProps setValue:[escapedStr copy] forKey:name];
+            [objectProps setValue:str forKey:name];
         }
     }
     


### PR DESCRIPTION
URLs are all set up using NSURLQueryItem rather than string concatenation, so parameters were getting encoded twice.

Generally this wasn't a problem because nobody issues tokens containing special characters, but it was broken for scopes like github's user:email or write:public_key