### PR TITLE
Android - Implement support for space separated scopes

### DIFF
--- a/android/src/main/java/io/fullstack/oauth/OAuthManagerProviders.java
+++ b/android/src/main/java/io/fullstack/oauth/OAuthManagerProviders.java
@@ -268,11 +268,19 @@ public class OAuthManagerProviders {
       builder.scope(scopeStr);
     }
 
+    boolean rawScopes = (cfg.containsKey("rawScopes") && ((String)cfg.get("rawScopes")).equalsIgnoreCase("true"));
+
     if (opts != null && opts.hasKey("scopes")) {
       scopes = (String) opts.getString("scopes");
-      String scopeStr = OAuthManagerProviders.getScopeString(scopes, ",");
+      String scopeStr = null;
+      
+      if (!rawScopes)
+        scopeStr = OAuthManagerProviders.getScopeString(scopes, ",");
+      else
+        scopeStr = scopes;
+        
       builder.scope(scopeStr);
-    }
+    } 
 
     if (callbackUrl != null) {
       builder.callback(callbackUrl);


### PR DESCRIPTION
I had an issue with http://github.com/identityServer/IdentityServer3 where it expects a space separated list of scopes, while react-native-oauth supports a comma separated list. 

In the previous code, spaces are removed before the string is split by comma.

To use the option:

```javascript

    manager.addProvider({
        'our_provider': {
            auth_version: '2.0',
            authorize_url: 'http://example.com/authorize',
            access_token_url: 'http://example.com/token',
            access_token_verb: 'post',
            api_url: 'http://example.com/api',
            callback_url: ({app_name}) => `${app_name}://oauth`
        }
    });

    manager.configure({
      our_provider: {
        client_id: 'sample',
        client_secret: 'secret',
        consumer_key: 'must_be_provided_for_custom_provider',
        api_key: 'must_be_provided_for_custom_provider',
        consumer_secret: 'must_be_provided_for_custom_provider',
        rawScopes: 'true'
      }
    });

    manager.authorize('our_provider', {scopes: 'openid profile api1'});


```

This resolves the issue.

Note that I have not tested with ios.

Note that this PR is similar to https://github.com/fullstackreact/react-native-oauth/pull/121/commits/a0dd695128cfc555300a13f91dd2683a5fcf11e3, except that it is a non breaking change.