### PR TITLE
[React Native 0.48]: Error: Redefinition of RCTMethodInfo

### DIFF
--- a/ios/OAuthManager/OAuthManager.h
+++ b/ios/OAuthManager/OAuthManager.h
@@ -7,10 +7,10 @@
 
 #import <Foundation/Foundation.h>
 
-#if __has_include("RCTBridgeModule.h")
-    #import "RCTBridgeModule.h"
-#else
+#if __has_include(<React/RCTBridgeModule.h>)
     #import <React/RCTBridgeModule.h>
+#else
+    #import "RCTBridgeModule.h"
 #endif
 
 #if __has_include("RCTLinkingManager.h")


### PR DESCRIPTION
Build failed without this fix