### PR TITLE
Fix for non mobile friendly pages in Android

### DIFF
--- a/android/src/main/java/io/fullstack/oauth/OAuthManagerDialogFragment.java
+++ b/android/src/main/java/io/fullstack/oauth/OAuthManagerDialogFragment.java
@@ -109,7 +109,9 @@ public class OAuthManagerDialogFragment extends DialogFragment implements Advanc
         mWebView.setVisibility(View.VISIBLE);
         mWebView.getSettings().setJavaScriptEnabled(true);
         mWebView.getSettings().setDomStorageEnabled(true);
-        mWebView.getSettings().setUserAgentString("Mozilla/5.0 Google");
+        // mWebView.getSettings().setUserAgentString("Mozilla/5.0 Google");
+		String userAgent = new WebView(mReactContext.getApplicationContext()).getSettings().getUserAgentString();
+        mWebView.getSettings().setUserAgentString(userAgent);
 
 
         LayoutParams layoutParams = this.getFullscreenLayoutParams(context);


### PR DESCRIPTION
Fix for issue #153 
Assigning a user agent string generated by the device should make the login pages show in a mobile friendly format.