### PR TITLE
Add a reauthenticate method to expose refresh token use

### DIFF
--- a/android/src/main/java/io/fullstack/oauth/OAuthManagerModule.java
+++ b/android/src/main/java/io/fullstack/oauth/OAuthManagerModule.java
@@ -163,6 +163,21 @@ class OAuthManagerModule extends ReactContextBaseJavaModule {
   }
 
   @ReactMethod
+  public void reauthenticate(
+    final String providerName,
+    @Nullable final ReadableMap params,
+    final Callback callback)
+  {
+    Log.e(TAG, "Reauthenticate is not implemented for android");
+    WritableMap err = Arguments.createMap();
+    err.putString("status", "error");
+    err.putString("msg", "Reauthenticate is not implemented for android");
+    callback.invoke(err);
+    return;
+  }
+
+
+  @ReactMethod
   public void makeRequest(
     final String providerName, 
     final String urlString,

--- a/ios/OAuthManager/OAuthManager.m
+++ b/ios/OAuthManager/OAuthManager.m
@@ -383,6 +383,61 @@ RCT_EXPORT_METHOD(authorize:(NSString *)providerName
                    }];
 }
 
+RCT_EXPORT_METHOD(reauthenticate:(NSString *) providerName
+                  opts:(NSDictionary *) opts
+                  callback:(RCTResponseSenderBlock) callback)
+{
+    OAuthManager *manager = [OAuthManager sharedManager];
+    DCTAuthAccountStore *store = [manager accountStore];
+    NSMutableDictionary *cfg = [[manager getConfigForProvider:providerName] mutableCopy];
+
+    NSString *newToken = [opts valueForKey:@"accessToken"];
+
+    DCTAuthAccount *existingAccount = [manager accountForProvider:providerName];
+    if (existingAccount == nil) {
+        NSDictionary *resp = @{
+                               @"status": @"error",
+                               @"msg": [NSString stringWithFormat:@"No account found for %@", providerName]
+                               };
+        callback(@[resp]);
+    } else if (newToken != nil) {
+        DCTOAuth2Credential *existingCredential = existingAccount.credential;
+        existingAccount.credential = [[DCTOAuth2Credential alloc] initWithClientID:existingCredential.clientID
+                                                           clientSecret:existingCredential.clientSecret
+                                                               password:existingCredential.password
+                                                            accessToken:newToken
+                                                                      refreshToken: existingCredential.refreshToken
+                                                                   type:existingCredential.type];
+
+        [store saveAccount:existingAccount];
+        NSDictionary *accountResponse = [manager getAccountResponse:existingAccount cfg:cfg];
+        callback(@[[NSNull null], @{
+                       @"status": @"ok",
+                       @"provider": providerName,
+                       @"response": accountResponse
+                       }]);
+    } else {
+        [existingAccount reauthenticateWithHandler:^(DCTAuthResponse *response, NSError *error) {
+            if (error != nil) {
+                NSDictionary *resp = @{
+                                       @"status": @"error",
+                                       @"msg": [error localizedDescription]
+                                       };
+                callback(@[resp]);
+            }
+            else {
+                [store saveAccount:existingAccount];
+                NSDictionary *accountResponse = [manager getAccountResponse:existingAccount cfg:cfg];
+                callback(@[[NSNull null], @{
+                               @"status": @"ok",
+                               @"provider": providerName,
+                               @"response": accountResponse
+                               }]);
+            }
+        }];
+    }
+}
+
 RCT_EXPORT_METHOD(makeRequest:(NSString *)providerName
                   urlOrPath:(NSString *) urlOrPath
                   opts:(NSDictionary *) opts
@@ -403,6 +458,8 @@ RCT_EXPORT_METHOD(makeRequest:(NSString *)providerName
     
     NSDictionary *creds = [self credentialForAccount:providerName cfg:cfg];
     
+    id<DCTAuthAccountCredential> existingCredential = [existingAccount credential];
+
     // If we have the http in the string, use it as the URL, otherwise create one
     // with the configuration
     NSURL *apiUrl;
@@ -474,6 +531,11 @@ RCT_EXPORT_METHOD(makeRequest:(NSString *)providerName
             NSInteger statusCode = response.statusCode;
             NSData *rawData = response.data;
             
+            // if account.credential has changed through use of a refresh token, save the updated token
+            if ([existingAccount credential] != existingCredential) {
+                [[manager accountStore] saveAccount:existingAccount];
+            }
+
             NSError *err;
             NSArray *data;
             

--- a/react-native-oauth.js
+++ b/react-native-oauth.js
@@ -44,6 +44,13 @@ export default class OAuthManager {
     return promisify('authorize')(provider, options);
   }
 
+  reauthenticate(provider, opts={}) {
+    const options = Object.assign({}, this._options, opts, {
+      app_name: this.appName
+    })
+    return promisify('reauthenticate')(provider, options);
+  }
+
   savedAccounts(opts={}) {
     // const options = Object.assign({}, this._options, opts, {
       // app_name: this.appName


### PR DESCRIPTION
This update improves the handling of refresh tokens when using a javascript api rather than the native makeRequest. Somewhat related to #82.

JS code can call reauthenticate to get a new token when a request fails due to an expired token.

I also added saving of the new token after a refresh - previously the new token would be in memory for subsequent makeRequest calls, but the next app startup would return the expired token.

iOS only for now - the android implementation is fairly straightforward, but isn't included as I'm not set up to test that at the moment.