### PR TITLE
Handle OAuth responses as querystring as well as JSON on Android

### DIFF
--- a/android/src/main/java/io/fullstack/oauth/OAuthManagerModule.java
+++ b/android/src/main/java/io/fullstack/oauth/OAuthManagerModule.java
@@ -7,6 +7,7 @@ import android.support.annotation.Nullable;
 import android.util.Log;
 
 import com.google.gson.Gson;
+import com.google.gson.JsonSyntaxException;
 
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.Callback;
@@ -400,9 +401,25 @@ class OAuthManagerModule extends ReactContextBaseJavaModule {
   ) {
     WritableMap resp = Arguments.createMap();
     WritableMap response = Arguments.createMap();
-    Map accessTokenMap = new Gson().fromJson(accessToken.getRawResponse(), Map.class);
-
     Log.d(TAG, "Credential raw response: " + accessToken.getRawResponse());
+
+    /* Some things return as JSON, some as x-www-form-urlencoded (querystring) */
+
+    Map accessTokenMap = null;
+    try {
+      accessTokenMap = new Gson().fromJson(accessToken.getRawResponse(), Map.class);
+    } catch (JsonSyntaxException e) {
+      /*
+      failed to parse as JSON, so turn it into a HashMap which looks like the one we'd
+      get back from the JSON parser, so the rest of the code continues unchanged.
+      */
+      Log.d(TAG, "Credential looks like a querystring; parsing as such");
+      accessTokenMap = new HashMap();
+      accessTokenMap.put("user_id", accessToken.getParameter("user_id"));
+      accessTokenMap.put("oauth_token_secret", accessToken.getParameter("oauth_token_secret"));
+      accessTokenMap.put("token_type", accessToken.getParameter("token_type"));
+    }
+
     
     resp.putString("status", "ok");
     resp.putBoolean("authorized", true);


### PR DESCRIPTION
Twitter, for example, returns OAuth token data as a querystring (x-www-form-urlencoded), not as JSON, so signing in breaks as per https://github.com/fullstackreact/react-native-oauth/issues/165.
Correct this by catching the JSON parse error and falling back to extracting the parameters we need from the token instead.