### PR TITLE
Use asynchronous execution for safariViewController

### DIFF
--- a/ios/OAuthManager/OAuthManager.m
+++ b/ios/OAuthManager/OAuthManager.m
@@ -88,9 +88,11 @@ RCT_EXPORT_MODULE(OAuthManager);
     [authPlatform setURLOpener: ^void(NSURL *URL, DCTAuthPlatformCompletion completion) {
         // [sharedManager setPendingAuthentication:YES];
         if ([SFSafariViewController class] != nil) {
-            safariViewController = [[SFSafariViewController alloc] initWithURL:URL];
-            UIViewController *viewController = application.keyWindow.rootViewController;
-            [viewController presentViewController:safariViewController animated:YES completion: nil];
+            dispatch_async(dispatch_get_main_queue(), ^{
+                safariViewController = [[SFSafariViewController alloc] initWithURL:URL];
+                UIViewController *viewController = application.keyWindow.rootViewController;
+                [viewController presentViewController:safariViewController animated:YES completion: nil];
+            });
         } else {
             [application openURL:URL];
         }


### PR DESCRIPTION
This prevents from updating an animated UI component's state from a
background thread and fixes related app crashes on iOS