### PR TITLE
Dispatch safariViewController on main queue

### DIFF
--- a/ios/OAuthManager/OAuthManager.h
+++ b/ios/OAuthManager/OAuthManager.h
@@ -7,16 +7,16 @@
 
 #import <Foundation/Foundation.h>
 
-#if __has_include("RCTBridgeModule.h")
-    #import "RCTBridgeModule.h"
-#else
+#if __has_include(<React/RCTBridgeModule.h>)
     #import <React/RCTBridgeModule.h>
+#else
+    #import "RCTBridgeModule.h"
 #endif
 
-#if __has_include("RCTLinkingManager.h")
-    #import "RCTLinkingManager.h"
-#else
+#if __has_include(<React/RCTLinkingManager.h>)
     #import <React/RCTLinkingManager.h>
+#else
+    #import "RCTLinkingManager.h"
 #endif
 
 

--- a/ios/OAuthManager/OAuthManager.m
+++ b/ios/OAuthManager/OAuthManager.m
@@ -91,7 +91,9 @@ RCT_EXPORT_MODULE(OAuthManager);
             dispatch_async(dispatch_get_main_queue(), ^{
                 safariViewController = [[SFSafariViewController alloc] initWithURL:URL];
                 UIViewController *viewController = application.keyWindow.rootViewController;
-                [viewController presentViewController:safariViewController animated:YES completion: nil];
+                dispatch_async(dispatch_get_main_queue(), ^{
+                    [viewController presentViewController:safariViewController animated:YES completion: nil];
+                });
             });
         } else {
             [application openURL:URL];


### PR DESCRIPTION
The safariViewController dispatch was occuring on another thread.
This sometimes caused app crashes when the view was presented,
in particular if the keyboard had been presented via a TextInput or
other component. The resulting crash complained about
_cachedSystemAnimationFence and the main thread. This has been with
other React Native apps that load a viewController.

Dispatching to present the viewController on the main thread fixes this
issue.