### PR TITLE
Fix: Duplicate RCTMethodInfo while building iOS app

### DIFF
--- a/ios/OAuthManager/OAuthManager.h
+++ b/ios/OAuthManager/OAuthManager.h
@@ -7,16 +7,16 @@
 
 #import <Foundation/Foundation.h>
 
-#if __has_include("RCTBridgeModule.h")
-    #import "RCTBridgeModule.h"
-#else
+#if __has_include(<React/RCTBridgeModule.h>)
     #import <React/RCTBridgeModule.h>
+#else
+    #import "RCTBridgeModule.h"
 #endif
 
-#if __has_include("RCTLinkingManager.h")
-    #import "RCTLinkingManager.h"
-#else
+#if __has_include(<React/RCTLinkingManager.h>)
     #import <React/RCTLinkingManager.h>
+#else
+    #import "RCTLinkingManager.h"
 #endif
 
 


### PR DESCRIPTION
The current module is facing an issue similar to this one: https://github.com/yonahforst/react-native-permissions/issues/137