### PR TITLE
Android API 26+ compatibility fix.

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -12,13 +12,19 @@ buildscript {
 apply plugin: 'com.android.library'
 apply plugin: 'maven'
 
+def _ext = rootProject.ext;
+def _compileSdkVersion = _ext.has('compileSdkVersion') ? _ext.compileSdkVersion : 26;
+def _buildToolsVersion = _ext.has('buildToolsVersion') ? _ext.buildToolsVersion : '26.0.3';
+def _minSdkVersion = _ext.has('minSdkVersion') ? _ext.minSdkVersion : 16;
+def _targetSdkVersion = _ext.has('targetSdkVersion') ? _ext.targetSdkVersion : 26;
+
 android {
-    compileSdkVersion 23
-    buildToolsVersion "23.0.1"
+    compileSdkVersion _compileSdkVersion
+    buildToolsVersion _buildToolsVersion
 
     defaultConfig {
-        minSdkVersion 16
-        targetSdkVersion 23
+        minSdkVersion _minSdkVersion
+        targetSdkVersion _targetSdkVersion
         versionCode 1
         versionName "1.0"
         multiDexEnabled  true


### PR DESCRIPTION
Work with target and compile SDK above 26 requires to raise target SDK API not less than 26.