### PR TITLE
Fixed disallowed_useragent issue for Google authentication on Android

### DIFF
--- a/android/src/main/java/io/fullstack/oauth/OAuthManagerDialogFragment.java
+++ b/android/src/main/java/io/fullstack/oauth/OAuthManagerDialogFragment.java
@@ -109,7 +109,7 @@ public class OAuthManagerDialogFragment extends DialogFragment implements Advanc
         mWebView.setVisibility(View.VISIBLE);
         mWebView.getSettings().setJavaScriptEnabled(true);
         mWebView.getSettings().setDomStorageEnabled(true);
-
+        mWebView.getSettings().setUserAgentString("Mozilla/5.0 (Linux; Android 4.1.1; Galaxy Nexus Build/JRO03C) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19");
 
         LayoutParams layoutParams = this.getFullscreenLayoutParams(context);
         //new LayoutParams(


### PR DESCRIPTION
Closes #87 

This sets the webview User-Agent header to solve the `disallowed_useragent` issue for Google authentication on Android.