### PR TITLE
Add refresh token on android

### DIFF
--- a/android/src/main/java/io/fullstack/oauth/OAuthManagerModule.java
+++ b/android/src/main/java/io/fullstack/oauth/OAuthManagerModule.java
@@ -470,6 +470,7 @@ class OAuthManagerModule extends ReactContextBaseJavaModule {
     Log.d(TAG, "Credential raw response: " + accessToken.getRawResponse());
     
     credentials.putString("accessToken", accessToken.getAccessToken());
+    credentials.putString("refreshToken", accessToken.getRefreshToken());
     String authHeader;
 
     String tokenType = accessToken.getTokenType();


### PR DESCRIPTION
Actually the refresh token could not be retrieved from JS on android.

This makes token renewal impossible.